### PR TITLE
Do not print which bazel version is being used

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -104,7 +104,6 @@ def main(argv=None):
 
     bazel_version = decide_which_bazel_version_to_use()
     bazel_version = resolve_version_label_to_number(bazelisk_directory, bazel_version)
-    print('Using Bazel {}...'.format(bazel_version))
 
     bazel_directory = os.path.join(bazelisk_directory, "bin")
     os.makedirs(bazel_directory, exist_ok=True)


### PR DESCRIPTION
This is very noise as it prints that on each invokation and we define the strict version in .bazelversion anyway.

Possibly it would make sense to keep this for the latest->version resolve? But even then if someone is unsure of the version they could just run `bazel version`