### PR TITLE
Update resolve_latest_version to always get latest

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from distutils.version import LooseVersion
+import json
 import platform
 import os.path
 import subprocess
@@ -54,9 +56,14 @@ def find_workspace_root(root=None):
     return find_workspace_root(new_root) if new_root != root else None
 
 def resolve_latest_version():
-    req = urllib.request.Request('https://github.com/bazelbuild/bazel/releases/latest', method='HEAD')
-    res = urllib.request.urlopen(req)
-    return res.geturl().split('/')[-1]
+    req = urllib.request.Request('https://api.github.com/repos/bazelbuild/bazel/releases', method='GET')
+    res = urllib.request.urlopen(req).read()
+    releases = json.loads(res.decode('utf-8'))
+
+    latest_version = LooseVersion(releases[0]["tag_name"])
+    for release in releases:
+        latest_version = max(latest_version, LooseVersion(release["tag_name"]))
+    return latest_version.__str__()
 
 def resolve_version_label_to_number(bazelisk_directory, version):
     if version == "latest":


### PR DESCRIPTION
Previously, it would not get the latest major/minor version if a
minor/patch version of a previous release was released chronologically
later.