### PR TITLE
Add support for release candidate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ It uses a simple algorithm:
 
 Bazelisk currently understands the following formats for version labels:
 - `latest` means the latest stable version of Bazel as released on GitHub.
-- A version number like `0.17.2` means that exact version of Bazel.
+- A version number like `0.17.2` means that exact version of Bazel. It can also
+  be a release candidate version like `0.20.0rc3`.
 
 In the future I will add support for release candidates and for building Bazel from source at a given commit.
 

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -91,9 +91,25 @@ def determine_bazel_filename(version):
 
     return "bazel-{}-{}-{}".format(version, operating_system, machine)
 
+def determine_release_or_rc(version):
+    parts = version.lower().split("rc")
+    if len(parts) == 1:
+        # e.g. ("0.20.0", "release") for 0.20.0
+        return (version, "release")
+    elif len(parts) == 2:
+        # e.g. ("0.20.0", "rc2") for 0.20.0rc2
+        return (parts[0], "rc" + parts[1])
+    else:
+        raise Exception("Invalid version: {}. Versions must be in the form <x>.<y>.<z>[rc<rc-number>]".format(version))
+
+
 def download_bazel_into_directory(version, directory):
     bazel_filename = determine_bazel_filename(version)
-    url = "https://releases.bazel.build/{}/release/{}".format(version, bazel_filename)
+    (parsed_version, release_or_rc) = determine_release_or_rc(version)
+    url = "https://releases.bazel.build/{}/{}/{}".format(
+            parsed_version,
+            release_or_rc,
+            bazel_filename)
     destination_path = os.path.join(directory, bazel_filename)
     if not os.path.exists(destination_path):
         sys.stderr.write("Downloading {}...\n".format(url))


### PR DESCRIPTION
This adds support for `rc` versions, like this:

```
$ USE_BAZEL_VERSION=0.20.0rc1 bazelisk build //src:bazel
Using Bazel 0.20.0rc1...
Downloading https://releases.bazel.build/0.20.0/rc1/bazel-0.20.0rc1-darwin-x86_64...
```