### PR TITLE
On keyboard interrupt, wait for Bazel to terminate.

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -153,7 +153,14 @@ def main(argv=None):
   maybe_makedirs(bazel_directory)
   bazel_path = download_bazel_into_directory(bazel_version, bazel_directory)
 
-  return subprocess.Popen([bazel_path] + argv[1:], close_fds=True).wait()
+  p = subprocess.Popen([bazel_path] + argv[1:], close_fds=True)
+  while True:
+    try:
+      return p.wait()
+    except KeyboardInterrupt:
+      # Bazel will also get the signal and terminate.
+      # We should continue waiting until it does so.
+      pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
From @natpen in #9:
"Before this, if you’re doing something like runinng tests and
then hit ctrl-c, the python dies first, and then the still-running
bazel process continues to write things to stdout until it exits itself.""