### PR TITLE
Support "latest-N" version strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ It uses a simple algorithm:
 - Otherwise it will check GitHub for the latest version of Bazel, cache the result for an hour and use that version.
 
 Bazelisk currently understands the following formats for version labels:
-- `latest` means the latest stable version of Bazel as released on GitHub.
+- `latest` means the latest stable version of Bazel as released on GitHub. Previous
+  releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel. It can also
   be a release candidate version like `0.20.0rc3`.
 

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -175,6 +175,7 @@ def main(argv=None):
   bazel_version = decide_which_bazel_version_to_use()
   bazel_version = resolve_version_label_to_number(bazelisk_directory,
                                                   bazel_version)
+
   bazel_directory = os.path.join(bazelisk_directory, 'bin')
   maybe_makedirs(bazel_directory)
   bazel_path = download_bazel_into_directory(bazel_version, bazel_directory)

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -88,6 +88,7 @@ def resolve_version_label_to_number(bazelisk_directory, version):
 
 
 def get_version_history(bazelisk_directory):
+  """Returns the most recent versions of Bazel, in descending order."""
   latest_cache = os.path.join(bazelisk_directory, 'latest_bazel')
   if os.path.exists(latest_cache):
     if abs(time.time() - os.path.getmtime(latest_cache)) < ONE_HOUR:
@@ -115,6 +116,7 @@ def resolve_latest_version(version_history, offset):
     raise Exception('Cannot resolve version "{}": There are only {} Bazel '
                     'releases.'.format(version, len(version_history)))
 
+  # This only works since we store the history in descending order.
   return version_history[offset]
 
 


### PR DESCRIPTION
Bazelisk now accepts "latest-1" to refer to the previous Bazel release, "latest-2" for the one before that, etc.

The current release can still be addressed as "latest" (but "latest-0" is also allowed).