### PR TITLE
Support "last_green" Bazel binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Bazelisk currently understands the following formats for version labels:
   releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel. It can also
   be a release candidate version like `0.20.0rc3`.
-- `last_green` refers to the Bazel binary that was built as part of the most recent successfull run on [Bazel CI](https://buildkite.com/bazel/bazel-bazel). Ideally this binary should be very close to Bazel-at-head.
+- `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel). Ideally this binary should be very close to Bazel-at-head.
 
 In the future I will add support for release candidates and for building Bazel from source at a given commit.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Bazelisk currently understands the following formats for version labels:
   releases can be specified via `latest-1`, `latest-2` etc.
 - A version number like `0.17.2` means that exact version of Bazel. It can also
   be a release candidate version like `0.20.0rc3`.
+- `last_green` refers to the Bazel binary that was built as part of the most recent successfull run on [Bazel CI](https://buildkite.com/bazel/bazel-bazel). Ideally this binary should be very close to Bazel-at-head.
 
 In the future I will add support for release candidates and for building Bazel from source at a given commit.
 

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -100,7 +100,12 @@ func getReleasesJSON(bazeliskHome string) ([]byte, error) {
 	}
 
 	// We could also use go-github here, but I can't get it to build with Bazel's rules_go and it pulls in a lot of dependencies.
-	return readRemoteFile("https://api.github.com/repos/bazelbuild/bazel/releases")
+	body, err := readRemoteFile("https://api.github.com/repos/bazelbuild/bazel/releases")
+	if err != nil {
+		return nil, fmt.Errorf("Could not retrieve list of releases from GitHub: %v", err)
+	}
+
+	return body, nil
 }
 
 func readRemoteFile(url string) ([]byte, error) {

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -161,6 +161,10 @@ func resolveLatestVersion(bazeliskHome string, offset int) (string, error) {
 }
 
 func resolveVersionLabel(bazeliskHome, bazelVersion string) (string, bool, error) {
+	// Returns three values:
+	// 1. The label of a Blaze release (if the label resolves to a release) or a commit (for unreleased binaries),
+	// 2. Whether the first value refers to a commit,
+	// 3. An error.
 	if bazelVersion == "last_green" {
 		commit, err := getLastGreenCommit()
 		if err != nil {

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -105,6 +105,11 @@ func getReleasesJSON(bazeliskHome string) ([]byte, error) {
 		return nil, fmt.Errorf("could not retrieve list of releases from GitHub: %v", err)
 	}
 
+	err = ioutil.WriteFile(cachePath, body, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("could not create %s: %v", cachePath, err)
+	}
+
 	return body, nil
 }
 

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -102,7 +102,7 @@ func getReleasesJSON(bazeliskHome string) ([]byte, error) {
 	// We could also use go-github here, but I can't get it to build with Bazel's rules_go and it pulls in a lot of dependencies.
 	body, err := readRemoteFile("https://api.github.com/repos/bazelbuild/bazel/releases")
 	if err != nil {
-		return nil, fmt.Errorf("Could not retrieve list of releases from GitHub: %v", err)
+		return nil, fmt.Errorf("could not retrieve list of releases from GitHub: %v", err)
 	}
 
 	return body, nil
@@ -159,7 +159,7 @@ func resolveVersionLabel(bazeliskHome, bazelVersion string) (string, bool, error
 	if bazelVersion == "last_green" {
 		commit, err := getLastGreenCommit()
 		if err != nil {
-			return "", false, fmt.Errorf("Cannot resolve last green commit: %v", err)
+			return "", false, fmt.Errorf("cannot resolve last green commit: %v", err)
 		}
 
 		return commit, true, nil
@@ -187,7 +187,7 @@ func resolveVersionLabel(bazeliskHome, bazelVersion string) (string, bool, error
 func getLastGreenCommit() (string, error) {
 	content, err := readRemoteFile("https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/github.com/bazelbuild/bazel.git/bazel-bazel")
 	if err != nil {
-		return "", fmt.Errorf("Could not get last green commit: %v", err)
+		return "", fmt.Errorf("could not determine last green commit: %v", err)
 	}
 	return strings.TrimSpace(string(content)), nil
 }

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -79,6 +79,18 @@ def find_workspace_root(root=None):
 
 
 def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
+    """Resolves the given label to a released version of Bazel or a commit.
+
+    Args:
+        bazelisk_directory: string; path to a directory that can store
+            temporary data for Bazelisk.
+        version: string; the version label that should be resolved.
+    Returns:
+        A (string, bool) tuple that consists of two parts:
+        1. the resolved number of a Bazel release (candidate), or the commit
+            of an unreleased Bazel binary,
+        2. An indicator for whether the returned version refers to a commit.
+    """
     if version == "last_green":
         return get_last_green_commit(), True
 

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -105,6 +105,17 @@ function test_bazel_latest_minus_3() {
       (echo "FAIL: Expected to find 'Build label' in the output of 'bazelisk version'"; exit 1)
 }
 
+function test_bazel_last_green() {
+  setup
+
+  USE_BAZEL_VERSION="last_green" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  ! grep "Build label:" log || \
+      (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
+}
+
 echo "# test_bazel_version"
 test_bazel_version
 echo
@@ -119,4 +130,8 @@ echo
 
 echo "# test_bazel_latest_minus_3"
 test_bazel_latest_minus_3
+echo
+
+echo "# test_bazel_last_green"
+test_bazel_last_green
 echo


### PR DESCRIPTION
This commit introduces the "last_green" version specifier that allows Bazelisk users to run a Bazel binary that was built at the last green commit of https://buildkite.com/bazel/bazel-bazel, which should be close to Bazel-at-head (ideally).

Both the Python and the Go implementation have been updated.