### PR TITLE
Add --migrate flag to bazelisk in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ Bazelisk currently understands the following formats for version labels:
 
 In the future I will add support for release candidates and for building Bazel from source at a given commit.
 
+## Other features
+
+The Go version of Bazlisk offers two new flags.
+
+`--strict` expands to the set of incompatible flags which may be enabled for the
+given version of Bazel.
+
+```shell
+bazelisk --strict build //...
+```
+
+`--migrate` will run Bazel multiple times to help you identify compatibility
+issues. If the code fails with `--strict`, the flag `--migrate` will run Bazel
+with each one of the flag separately, and print a report at the end. This will
+show you which flags can safely enabled, and which flags require a migration.
+
 ## Requirements
 
 For ease of use, the Python version of Bazelisk is written to work with Python 2.7 and 3.x and only uses modules provided by the standard library.

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -331,6 +331,65 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 	return result, nil
 }
 
+func migrate(bazelPath string, baseArgs []string, newArgs []string) {
+	// 1. Try with all the flags.
+	args := append(baseArgs, newArgs...)
+	fmt.Printf("Running Bazel with %q\n", args)
+	exitCode, err := runBazel(bazelPath, args)
+	if err != nil {
+		log.Fatalf("could not run Bazel: %v", err)
+	}
+	if exitCode == 0 {
+		fmt.Printf("Success: No migration needed.\n")
+		os.Exit(0)
+	}
+
+	// 2. Try with no flags, as a sanity check.
+	args = baseArgs
+	fmt.Printf("\n---\n\n")
+	fmt.Printf("Running Bazel with %q\n", args)
+	exitCode, err = runBazel(bazelPath, args)
+	if err != nil {
+		log.Fatalf("could not run Bazel: %v", err)
+	}
+	if exitCode != 0 {
+		fmt.Printf("Failure: Command failed, even without incomaptible flags.\n")
+		os.Exit(0)
+	}
+
+	// 3. Try with each flag separately.
+	var passList []string
+	var failList []string
+	for _, arg := range newArgs {
+		args = append(baseArgs, arg)
+		fmt.Printf("\n---\n\n")
+		fmt.Printf("Running Bazel with %q\n", args)
+		exitCode, err = runBazel(bazelPath, args)
+		if err != nil {
+			log.Fatalf("could not run Bazel: %v", err)
+		}
+		if exitCode == 0 {
+			passList = append(passList, arg)
+		} else {
+			failList = append(failList, arg)
+		}
+	}
+
+	// 4. Print report
+	fmt.Printf("\n---\n\n")
+	fmt.Printf("Command was successful with the following flags:\n")
+	for _, arg := range passList {
+		fmt.Printf("  %s\n", arg)
+	}
+	fmt.Printf("\n")
+	fmt.Printf("Migration is needed for the following flags:\n")
+	for _, arg := range failList {
+		fmt.Printf("  %s\n", arg)
+	}
+
+	os.Exit(0)
+}
+
 func main() {
 	bazeliskHome := os.Getenv("BAZELISK_HOME")
 	if len(bazeliskHome) == 0 {
@@ -372,12 +431,18 @@ func main() {
 
 	// --strict must be the first argument. When it is present, it expands to the list of
 	// --incompatible_ flags that should be enabled for the given Bazel version.
-	if len(args) > 0 && args[0] == "--strict" {
+	if len(args) > 0 && args[0] == "--strict" || args[0] == "--migrate" {
+		cmd := args[0]
 		newFlags, err := getIncompatibleFlags(bazeliskHome, resolvedBazelVersion)
 		if err != nil {
 			log.Fatalf("could not get the list of incompatible flags: %v", err)
 		}
-		args = append(args[1:], newFlags...)
+
+		if cmd == "--migrate" {
+			migrate(bazelPath, args[1:], newFlags)
+		} else {
+			args = append(args[1:], newFlags...)
+		}
 	}
 
 	exitCode, err := runBazel(bazelPath, args)

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -331,6 +331,7 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 	return result, nil
 }
 
+// migrate will run Bazel with each newArgs separately and report which ones are failing.
 func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	// 1. Try with all the flags.
 	args := append(baseArgs, newArgs...)
@@ -353,7 +354,7 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 		log.Fatalf("could not run Bazel: %v", err)
 	}
 	if exitCode != 0 {
-		fmt.Printf("Failure: Command failed, even without incomaptible flags.\n")
+		fmt.Printf("Failure: Command failed, even without incompatible flags.\n")
 		os.Exit(0)
 	}
 
@@ -429,8 +430,7 @@ func main() {
 
 	args := os.Args[1:]
 
-	// --strict must be the first argument. When it is present, it expands to the list of
-	// --incompatible_ flags that should be enabled for the given Bazel version.
+	// --strict and --migrate must be the first argument.
 	if len(args) > 0 && args[0] == "--strict" || args[0] == "--migrate" {
 		cmd := args[0]
 		newFlags, err := getIncompatibleFlags(bazeliskHome, resolvedBazelVersion)
@@ -441,6 +441,8 @@ func main() {
 		if cmd == "--migrate" {
 			migrate(bazelPath, args[1:], newFlags)
 		} else {
+			// When --strict is present, it expands to the list of --incompatible_ flags
+			// that should be enabled for the given Bazel version.
 			args = append(args[1:], newFlags...)
 		}
 	}


### PR DESCRIPTION
This will try separately each incompatible flag and show a report. This
is useful for identifying issues in the current code base.