### PR TITLE
Optimize the output of `bazelisk --migrate ...` for Buildkite

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -365,6 +365,8 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 		}
 	}
 
+	sort.Strings(result)
+
 	return result, nil
 }
 
@@ -372,7 +374,7 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	// 1. Try with all the flags.
 	args := append(baseArgs, newArgs...)
-	fmt.Printf("Running Bazel with %q\n", args)
+	fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
 	exitCode, err := runBazel(bazelPath, args)
 	if err != nil {
 		log.Fatalf("could not run Bazel: %v", err)
@@ -384,8 +386,7 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 
 	// 2. Try with no flags, as a sanity check.
 	args = baseArgs
-	fmt.Printf("\n---\n\n")
-	fmt.Printf("Running Bazel with %q\n", args)
+	fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
 	exitCode, err = runBazel(bazelPath, args)
 	if err != nil {
 		log.Fatalf("could not run Bazel: %v", err)
@@ -400,8 +401,7 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	var failList []string
 	for _, arg := range newArgs {
 		args = append(baseArgs, arg)
-		fmt.Printf("\n---\n\n")
-		fmt.Printf("Running Bazel with %q\n", args)
+		fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
 		exitCode, err = runBazel(bazelPath, args)
 		if err != nil {
 			log.Fatalf("could not run Bazel: %v", err)
@@ -414,7 +414,7 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	}
 
 	// 4. Print report
-	fmt.Printf("\n---\n\n")
+	fmt.Printf("\n\n+++ Result\n\n")
 	fmt.Printf("Command was successful with the following flags:\n")
 	for _, arg := range passList {
 		fmt.Printf("  %s\n", arg)

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -374,7 +374,8 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	// 1. Try with all the flags.
 	args := append(baseArgs, newArgs...)
-	fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
+	fmt.Printf("\n\n--- Running Bazel with all incompatible flags\n\n")
+	fmt.Printf("bazel %s\n", strings.Join(args, " "))
 	exitCode, err := runBazel(bazelPath, args)
 	if err != nil {
 		log.Fatalf("could not run Bazel: %v", err)
@@ -386,7 +387,8 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 
 	// 2. Try with no flags, as a sanity check.
 	args = baseArgs
-	fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
+	fmt.Printf("\n\n--- Running Bazel with no incompatible flags\n\n", args)
+	fmt.Printf("bazel %s\n", strings.Join(args, " "))
 	exitCode, err = runBazel(bazelPath, args)
 	if err != nil {
 		log.Fatalf("could not run Bazel: %v", err)
@@ -401,7 +403,8 @@ func migrate(bazelPath string, baseArgs []string, newArgs []string) {
 	var failList []string
 	for _, arg := range newArgs {
 		args = append(baseArgs, arg)
-		fmt.Printf("\n\n--- Running Bazel with %q\n\n", args)
+		fmt.Printf("\n\n--- Running Bazel with %s\n\n", arg)
+		fmt.Printf("bazel %s\n", strings.Join(args, " "))
 		exitCode, err = runBazel(bazelPath, args)
 		if err != nil {
 			log.Fatalf("could not run Bazel: %v", err)


### PR DESCRIPTION
1. sort all incompatible flags
2. Use `---` to print the output of individual Bazel run as a collapsed group
3. Use `+++` to print the result as a expanded group

Related doc: https://buildkite.com/docs/pipelines/managing-log-output