### PR TITLE
Get up to 100 flags (instead of 30).

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -346,7 +346,7 @@ func getIncompatibleFlags(bazeliskHome, resolvedBazelVersion string) ([]string, 
 	if len(version) == 0 {
 		return nil, fmt.Errorf("invalid version %v", resolvedBazelVersion)
 	}
-	url := "https://api.github.com/search/issues?q=repo:bazelbuild/bazel+label:migration-" + version
+	url := "https://api.github.com/search/issues?per_page=100&q=repo:bazelbuild/bazel+label:migration-" + version
 	issuesJSON, err := maybeDownload(bazeliskHome, url, "flags-"+version, "list of flags from GitHub")
 	if err != nil {
 		return nil, fmt.Errorf("could not get issues from GitHub: %v", err)


### PR DESCRIPTION
Instead of hard-coding the limit, we could also make multiple requests,
one for each page (https://developer.github.com/v3/#pagination).

But we don't expect the number of flags to grow indefinitely, so a limit
should work.

Fixes https://github.com/philwo/bazelisk/issues/40