### PR TITLE
Update release candidate version format.

### DIFF
--- a/bazelisk.go
+++ b/bazelisk.go
@@ -240,7 +240,10 @@ func determineURL(version string, isCommit bool, filename string) string {
 
 	kind := "release"
 	if strings.Contains(version, "rc") {
-		kind = strings.SplitAfter(version, "rc")[1]
+		versionComponents := strings.Split(version, "rc")
+		// Replace version with the part before rc
+		version = versionComponents[0]
+		kind = "rc" + versionComponents[1]
 	}
 
 	return fmt.Sprintf("https://releases.bazel.build/%s/%s/%s", version, kind, filename)


### PR DESCRIPTION
Current format returns https://releases.bazel.build/0.24.0rc5/5/bazel-0.24.0rc5-darwin-x86_64 and instead
it should be https://releases.bazel.build/0.24.0/rc5/bazel-0.24.0rc5-darwin-x86_64.