### PR TITLE
Support last_downstream_green Bazel binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Bazelisk currently understands the following formats for version labels:
 - A version number like `0.17.2` means that exact version of Bazel. It can also
   be a release candidate version like `0.20.0rc3`.
 - `last_green` refers to the Bazel binary that was built at the most recent commit that passed [Bazel CI](https://buildkite.com/bazel/bazel-bazel). Ideally this binary should be very close to Bazel-at-head.
+- `last_downstream_green` points to the most recent Bazel binary that builds and tests all [downstream projects](https://buildkite.com/bazel/bazel-at-head-plus-downstream) successfully.
 
 
 In the future I will add support for release candidates and for building Bazel from source at a given commit.

--- a/bazelisk.go
+++ b/bazelisk.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -199,10 +198,10 @@ func resolveVersionLabel(bazeliskHome, bazelVersion string) (string, bool, error
 	return bazelVersion, false, nil
 }
 
-const lastGreenBasePath = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit"
+const lastGreenBasePath = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/"
 
 func getLastGreenCommit(pathSuffix string) (string, error) {
-	content, err := readRemoteFile(filepath.Join(lastGreenBasePath, pathSuffix))
+	content, err := readRemoteFile(lastGreenBasePath + pathSuffix)
 	if err != nil {
 		return "", fmt.Errorf("could not determine last green commit: %v", err)
 	}

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -36,7 +36,9 @@ ONE_HOUR = 1 * 60 * 60
 
 LATEST_PATTERN = re.compile(r"latest(-(?P<offset>\d+))?$")
 
-LAST_GREEN_COMMIT_FILE = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/github.com/bazelbuild/bazel.git/bazel-bazel"
+LAST_GREEN_COMMIT_BASE_PATH = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit"
+
+LAST_GREEN_COMMIT_PATH_SUFFIXES = {"last_green" : "github.com/bazelbuild/bazel.git/bazel-bazel", "last_downstream_green" : "downstream_pipeline"}
 
 BAZEL_GCS_PATH_PATTERN = (
     "https://storage.googleapis.com/bazel-builds/artifacts/{platform}/{commit}/bazel"
@@ -91,8 +93,9 @@ def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
             of an unreleased Bazel binary,
         2. An indicator for whether the returned version refers to a commit.
     """
-    if version == "last_green":
-        return get_last_green_commit(), True
+    suffix = LAST_GREEN_COMMIT_PATH_SUFFIXES.get(version)
+    if suffix:
+        return get_last_green_commit(suffix), True
 
     if "latest" in version:
         match = LATEST_PATTERN.match(version)
@@ -111,8 +114,9 @@ def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
     return version, False
 
 
-def get_last_green_commit():
-    return read_remote_text_file(LAST_GREEN_COMMIT_FILE).strip()
+def get_last_green_commit(path_suffix):
+    path = os.path.join(LAST_GREEN_COMMIT_BASE_PATH, path_suffix)
+    return read_remote_text_file(path).strip()
 
 
 def get_releases_json(bazelisk_directory):

--- a/bazelisk.py
+++ b/bazelisk.py
@@ -36,7 +36,7 @@ ONE_HOUR = 1 * 60 * 60
 
 LATEST_PATTERN = re.compile(r"latest(-(?P<offset>\d+))?$")
 
-LAST_GREEN_COMMIT_BASE_PATH = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit"
+LAST_GREEN_COMMIT_BASE_PATH = "https://storage.googleapis.com/bazel-untrusted-builds/last_green_commit/"
 
 LAST_GREEN_COMMIT_PATH_SUFFIXES = {"last_green" : "github.com/bazelbuild/bazel.git/bazel-bazel", "last_downstream_green" : "downstream_pipeline"}
 
@@ -115,8 +115,7 @@ def resolve_version_label_to_number_or_commit(bazelisk_directory, version):
 
 
 def get_last_green_commit(path_suffix):
-    path = os.path.join(LAST_GREEN_COMMIT_BASE_PATH, path_suffix)
-    return read_remote_text_file(path).strip()
+    return read_remote_text_file(LAST_GREEN_COMMIT_BASE_PATH + path_suffix).strip()
 
 
 def get_releases_json(bazelisk_directory):

--- a/bazelisk_test.sh
+++ b/bazelisk_test.sh
@@ -116,6 +116,17 @@ function test_bazel_last_green() {
       (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
 }
 
+function test_bazel_last_downstream_green() {
+  setup
+
+  USE_BAZEL_VERSION="last_downstream_green" \
+      BAZELISK_HOME="$BAZELISK_HOME" \
+      bazelisk version 2>&1 | tee log
+
+  ! grep "Build label:" log || \
+      (echo "FAIL: 'bazelisk version' of an unreleased binary must not print a build label."; exit 1)
+}
+
 echo "# test_bazel_version"
 test_bazel_version
 echo
@@ -134,4 +145,8 @@ echo
 
 echo "# test_bazel_last_green"
 test_bazel_last_green
+echo
+
+echo "# test_bazel_last_downstream_green"
+test_bazel_last_downstream_green
 echo


### PR DESCRIPTION
This commit modifies both Bazelisk implementations to support the
"last_downstream_green" version identifier, which refers to a Bazel
binary built at the most recent commit that passed the downstream
pipeline on CI (https://buildkite.com/bazel/bazel-at-head-plus-downstream).

Part of https://github.com/bazelbuild/continuous-integration/issues/583.

Note: We cannot merge this PR until the pipeline actually uploads its first green commit.