### PR TITLE
Make JSON exception version-agnostic

### DIFF
--- a/bazelisk.py
+++ b/bazelisk.py
@@ -128,7 +128,7 @@ def get_releases_json(bazelisk_directory):
             with open(releases, "rb") as f:
                 try:
                     return json.loads(f.read().decode("utf-8"))
-                except json.decoder.JSONDecodeError:
+                except ValueError:
                     print("WARN: Could not parse cached releases.json.")
                     pass
 


### PR DESCRIPTION
The `JSONDecodeError` type doesn't exist in Python 2.x:

```
Python 2.7.16 (default, Mar  4 2019, 09:01:38)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> dir(json)
['JSONDecoder', 'JSONEncoder', '__all__', '__author__', '__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', '__version__', '_default_decoder', '_default_encoder', 'decoder', 'dump', 'dumps', 'encoder', 'load', 'loads', 'scanner']
>>> dir(json.decoder)
['BACKSLASH', 'DEFAULT_ENCODING', 'FLAGS', 'JSONArray', 'JSONDecoder', 'JSONObject', 'NaN', 'NegInf', 'PosInf', 'STRINGCHUNK', 'WHITESPACE', 'WHITESPACE_STR', '_CONSTANTS', '__all__', '__builtins__', '__doc__', '__file__', '__name__', '__package__', '_decode_uXXXX', '_floatconstants', 'c_scanstring', 'errmsg', 'linecol', 'py_scanstring', 're', 'scanner', 'scanstring', 'struct', 'sys']
```

However, it's a subclass of the more-general `ValueError`, which *does* exist in Python 2. It should suffice to catch the more generic exception.

(I'm not sure if this script is supposed to be compatible with Python 2, but I assume yes.)